### PR TITLE
feat: modern chat drawer with markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,6 @@
         /* Cajón de chat */
         .drawer {
             position: fixed;
-            top: 0;
             left: 0;
             right: 0;
             bottom: -100%;
@@ -117,6 +116,7 @@
         }
 
         .drawer[aria-hidden="false"] {
+            top: 0;
             bottom: 0;
         }
 

--- a/index.html
+++ b/index.html
@@ -80,7 +80,6 @@
             bottom: 20px;
             right: 20px;
             padding: 10px 15px;
-            border-radius: 25px; /* Para hacerlo más redondeado */
             z-index: 999;
             cursor: pointer;
             opacity: 0.5; /* Estado inactivo */
@@ -103,7 +102,51 @@
             }
         }
 
-        .modal-overlay, .wizard-overlay {
+        /* Cajón de chat */
+        .drawer {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: -100%;
+            background-color: var(--overlay-bg-color);
+            display: flex;
+            align-items: flex-end;
+            z-index: 1000;
+            transition: bottom var(--dur, 240ms) var(--ease, ease);
+        }
+
+        .drawer[aria-hidden="false"] {
+            bottom: 0;
+        }
+
+        .drawer-body {
+            background-color: var(--background-color);
+            border: 1px solid var(--border-color);
+            padding: 1rem;
+            width: 100%;
+            max-height: 80vh;
+            display: flex;
+            flex-direction: column;
+            position: relative;
+        }
+
+        .drawer-close-button {
+            position: absolute;
+            top: 5px;
+            right: 10px;
+            background: none;
+            border: none;
+            font-family: sans-serif;
+            font-size: 24px;
+            cursor: pointer;
+            padding: 5px;
+            line-height: 1;
+            color: var(--text-color);
+        }
+
+        /* Estilos del wizard */
+        .wizard-overlay {
             position: fixed;
             top: 0;
             left: 0;
@@ -116,39 +159,14 @@
             z-index: 1000;
         }
 
-        .modal-content, .wizard-content {
+        .wizard-content {
             background-color: var(--background-color);
             border: 1px solid var(--border-color);
             padding: 1rem;
             width: 90%;
-            position: relative;
-        }
-
-        .modal-content {
-            max-width: 600px;
-            height: 80%;
-            max-height: 700px;
-            display: flex;
-            flex-direction: column;
-        }
-
-        .wizard-content {
             max-width: 500px;
             text-align: center;
-        }
-
-        .modal-close-button {
-            position: absolute;
-            top: 5px;
-            right: 10px;
-            background: none;
-            border: none;
-            font-family: sans-serif;
-            font-size: 24px;
-            cursor: pointer;
-            padding: 5px;
-            line-height: 1;
-            color: var(--text-color);
+            position: relative;
         }
 
         #selected-text-container {
@@ -168,12 +186,16 @@
             margin-bottom: 1rem;
         }
 
-        #chat-history p { margin: 0.5em 0; font-size: 1em; }
+        #chat-history div { margin: 0.5em 0; font-size: 1em; }
         #chat-history .user-message { font-weight: bold; }
-        #chat-history .model-message { white-space: pre-wrap; }
 
         #chat-form { display: flex; }
-        #chat-input { flex-grow: 1; margin-right: 0.5rem; }
+        #chat-input {
+            flex-grow: 1;
+            margin-right: 0.5rem;
+            resize: none;
+            height: 3rem;
+        }
     </style>
 </head>
 <body>
@@ -186,21 +208,21 @@
 
     <!-- Elementos de la Interfaz Interactiva -->
     <button id="highlighter-button">Conversar</button>
-    <button id="mobile-chat-trigger">💬 Conversar</button> <!-- NUEVO BOTÓN -->
+    <button id="mobile-chat-trigger">Conversar</button>
 
-    <!-- MODAL DEL CHAT -->
-    <div class="modal-overlay" id="ai-modal">
-        <div class="modal-content">
-            <button class="modal-close-button" id="modal-close">X</button>
+    <!-- CAJÓN DE CHAT -->
+    <aside id="chat-drawer" class="drawer" aria-hidden="true" inert>
+        <div class="drawer-body">
+            <button class="drawer-close-button" id="drawer-close">×</button>
             <h4>Conversando sobre:</h4>
             <div id="selected-text-container"></div>
             <div id="chat-history"></div>
             <form id="chat-form">
-                <input type="text" id="chat-input" placeholder="Haz una pregunta..." required>
+                <textarea id="chat-input" placeholder="Haz una pregunta..." required></textarea>
                 <button type="submit">Enviar</button>
             </form>
         </div>
-    </div>
+    </aside>
 
     <!-- WIZARD / TUTORIAL DE BIENVENIDA -->
     <div class="wizard-overlay" id="wizard">
@@ -212,6 +234,7 @@
         </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script type="module" src="main.js"></script>
 
 </body>

--- a/main.js
+++ b/main.js
@@ -17,10 +17,10 @@ if (API_KEY && API_KEY !== "AQUI_VA_TU_NUEVA_API_KEY") {
 // --- REFERENCIAS A ELEMENTOS DEL DOM ---
 const contentContainer = document.getElementById('content-container');
 const highlighterButton = document.getElementById('highlighter-button');
-const mobileChatTrigger = document.getElementById('mobile-chat-trigger'); // NUEVO
-// Modal de Chat
-const modal = document.getElementById('ai-modal');
-const modalCloseButton = document.getElementById('modal-close');
+const mobileChatTrigger = document.getElementById('mobile-chat-trigger');
+// Cajón de Chat
+const drawer = document.getElementById('chat-drawer');
+const drawerCloseButton = document.getElementById('drawer-close');
 const selectedTextContainer = document.getElementById('selected-text-container');
 const chatHistoryContainer = document.getElementById('chat-history');
 const chatForm = document.getElementById('chat-form');
@@ -126,7 +126,7 @@ function createElement(item) {
 // MODIFICADO: Se añade 'touchend' para mejor respuesta en móviles
 ['mouseup', 'touchend'].forEach(evt => {
     document.addEventListener(evt, (event) => {
-        if (modal.contains(event.target) || wizard.contains(event.target)) return;
+        if (drawer.contains(event.target) || wizard.contains(event.target)) return;
         
         const selection = window.getSelection();
         const selectedText = selection.toString().trim();
@@ -149,33 +149,36 @@ function createElement(item) {
 });
 
 // Refactorizado para evitar duplicar código
-function openChatModal() {
+function openChatDrawer() {
     if (!genAI) {
         alert("La funcionalidad de IA no está disponible. Por favor, configura una clave de API en el archivo main.js.");
         return;
     }
     selectedTextContainer.textContent = `"${currentSelectedText}"`;
     chatHistoryContainer.innerHTML = '';
-    modal.style.display = 'flex';
+    drawer.setAttribute('aria-hidden', 'false');
+    drawer.removeAttribute('inert');
     highlighterButton.style.display = 'none';
     mobileChatTrigger.classList.remove('active'); // Desactivar al abrir
     startChatSession();
+    drawerCloseButton.focus();
 }
 
-highlighterButton.addEventListener('click', openChatModal);
+highlighterButton.addEventListener('click', openChatDrawer);
 mobileChatTrigger.addEventListener('click', () => {
     if (mobileChatTrigger.classList.contains('active')) {
-        openChatModal();
+        openChatDrawer();
     }
 });
 
-function closeModal() {
-    modal.style.display = 'none';
+function closeDrawer() {
+    drawer.setAttribute('aria-hidden', 'true');
+    drawer.setAttribute('inert', '');
     chat = null;
 }
-modalCloseButton.addEventListener('click', closeModal);
-modal.addEventListener('click', (event) => {
-    if (event.target === modal) closeModal();
+drawerCloseButton.addEventListener('click', closeDrawer);
+drawer.addEventListener('click', (event) => {
+    if (event.target === drawer) closeDrawer();
 });
 
 chatForm.addEventListener('submit', async (event) => {
@@ -195,7 +198,11 @@ chatForm.addEventListener('submit', async (event) => {
         for await (const chunk of stream.stream) {
             const chunkText = chunk.text();
             modelResponse += chunkText;
-            modelMessageElement.textContent = modelResponse;
+            if (window.marked) {
+                modelMessageElement.innerHTML = marked.parse(modelResponse);
+            } else {
+                modelMessageElement.textContent = modelResponse;
+            }
             chatHistoryContainer.scrollTop = chatHistoryContainer.scrollHeight;
         }
     } catch (error) {
@@ -208,13 +215,16 @@ chatForm.addEventListener('submit', async (event) => {
 });
 
 function addMessageToHistory(text, role) {
-    // ... (Esta función no cambia)
-    const p = document.createElement('p');
-    p.textContent = text;
-    p.className = role === 'user' ? 'user-message' : 'model-message';
-    chatHistoryContainer.appendChild(p);
+    const el = document.createElement('div');
+    el.className = role === 'user' ? 'user-message' : 'model-message';
+    if (role === 'model' && window.marked) {
+        el.innerHTML = marked.parse(text);
+    } else {
+        el.textContent = text;
+    }
+    chatHistoryContainer.appendChild(el);
     chatHistoryContainer.scrollTop = chatHistoryContainer.scrollHeight;
-    return p;
+    return el;
 }
 
 function startChatSession() {


### PR DESCRIPTION
## Summary
- Replace modal chat with a sliding bottom drawer using accessible controls
- Render model responses as Markdown and switch to a larger multiline chat input
- Unify mobile chat trigger styling with the rest of the interface

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b98eb4e05483258ba5467e5d0998bc