### PR TITLE
Improve mobile selection flow for Conversar button

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,19 +77,40 @@
         #mobile-chat-trigger {
             display: none; /* Oculto por defecto */
             position: fixed;
-            bottom: 20px;
-            right: 20px;
+            top: 12px;
+            left: 12px;
             padding: 10px 15px;
-            z-index: 999;
+            z-index: 1500;
             cursor: pointer;
-            opacity: 0.5; /* Estado inactivo */
-            pointer-events: none; /* No se puede hacer clic cuando está inactivo */
-            transition: opacity 0.2s;
+            opacity: 0.9;
+            transition: opacity 0.2s, border-color 0.2s, box-shadow 0.2s;
         }
 
-        #mobile-chat-trigger.active {
-            opacity: 1; /* Estado activo */
-            pointer-events: auto; /* Se puede hacer clic */
+        #mobile-chat-trigger.selection-mode {
+            opacity: 1;
+            box-shadow: 0 0 0 2px var(--border-color);
+        }
+
+        #mobile-chat-trigger.ready {
+            border-style: solid;
+        }
+
+        #mobile-selection-hint {
+            display: none;
+            position: fixed;
+            top: 60px;
+            left: 12px;
+            right: 12px;
+            padding: 0.75rem 1rem;
+            border: 1px solid var(--border-color);
+            background-color: var(--background-color);
+            color: var(--text-color);
+            z-index: 1400;
+            font-size: 0.95rem;
+        }
+
+        #mobile-selection-hint.visible {
+            display: block;
         }
 
         /* --- NUEVO: Media Query para lógica móvil --- */
@@ -99,6 +120,7 @@
             }
             #mobile-chat-trigger {
                 display: block; /* Mostrar el botón flotante en móviles */
+                pointer-events: auto;
             }
         }
 
@@ -208,7 +230,8 @@
 
     <!-- Elementos de la Interfaz Interactiva -->
     <button id="highlighter-button">Conversar</button>
-    <button id="mobile-chat-trigger">Conversar</button>
+    <button id="mobile-chat-trigger" aria-expanded="false">Conversar</button>
+    <div id="mobile-selection-hint" role="status" aria-live="polite"></div>
 
     <!-- CAJÓN DE CHAT -->
     <aside id="chat-drawer" class="drawer" aria-hidden="true" inert>

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
             position: fixed;
             top: 12px;
             left: 12px;
-            padding: 10px 15px;
+            padding: 5px 10px;
             z-index: 1500;
             cursor: pointer;
             opacity: 0.9;
@@ -178,26 +178,56 @@
             display: none;
             align-items: center;
             justify-content: center;
-            z-index: 1000;
+            z-index: 2400;
         }
 
         .wizard-content {
             background-color: var(--background-color);
             border: 1px solid var(--border-color);
-            padding: 1rem;
+            padding: 1.5rem;
             width: 90%;
-            max-width: 500px;
-            text-align: center;
+            max-width: 520px;
+            text-align: left;
             position: relative;
+            box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
         }
 
-        #selected-text-container {
-            border-bottom: 1px solid var(--border-color);
-            padding-bottom: 0.5rem;
+        .wizard-content h2 {
+            margin-top: 0;
+        }
+
+        #wizard-subtitle {
+            font-size: 1.05em;
+            margin: 0.25rem 0 1rem;
+        }
+
+        #wizard-instructions {
+            margin: 0 0 1.25rem 1rem;
+            padding-left: 1rem;
+            list-style-position: inside;
+        }
+
+        #wizard-instructions li {
             margin-bottom: 0.5rem;
-            font-style: italic;
-            max-height: 100px;
-            overflow-y: auto;
+        }
+
+        .wizard-actions {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .wizard-actions label {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 0.95em;
+        }
+
+        .wizard-actions button {
+            padding: 5px 10px;
         }
 
         #chat-history {
@@ -237,9 +267,7 @@
     <aside id="chat-drawer" class="drawer" aria-hidden="true" inert>
         <div class="drawer-body">
             <button class="drawer-close-button" id="drawer-close">×</button>
-            <h4>Conversando sobre:</h4>
-            <div id="selected-text-container"></div>
-            <div id="chat-history"></div>
+            <div id="chat-history" role="log" aria-live="polite"></div>
             <form id="chat-form">
                 <textarea id="chat-input" placeholder="Haz una pregunta..." required></textarea>
                 <button type="submit">Enviar</button>
@@ -248,12 +276,15 @@
     </aside>
 
     <!-- WIZARD / TUTORIAL DE BIENVENIDA -->
-    <div class="wizard-overlay" id="wizard">
+    <div class="wizard-overlay" id="wizard" role="dialog" aria-modal="true" aria-labelledby="wizard-title" aria-hidden="true">
         <div class="wizard-content">
-            <h2>Bienvenido a Arqueidentidad: Omicron</h2>
-            <p style="font-size: 1.2em;">Esta es una página interactiva.</p>
-            <p><strong>Selecciona cualquier fragmento de texto</strong> para iniciar una conversación con una IA experta sobre ese concepto.</p>
-            <button id="wizard-close">Entendido</button>
+            <h2 id="wizard-title">Bienvenido</h2>
+            <p id="wizard-subtitle"></p>
+            <ol id="wizard-instructions"></ol>
+            <div class="wizard-actions">
+                <label for="wizard-dont-show"><input type="checkbox" id="wizard-dont-show"> No mostrar de nuevo</label>
+                <button id="wizard-close" type="button">Comenzar</button>
+            </div>
         </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -22,7 +22,6 @@ const mobileSelectionHint = document.getElementById('mobile-selection-hint');
 // Cajón de Chat
 const drawer = document.getElementById('chat-drawer');
 const drawerCloseButton = document.getElementById('drawer-close');
-const selectedTextContainer = document.getElementById('selected-text-container');
 const chatHistoryContainer = document.getElementById('chat-history');
 const chatForm = document.getElementById('chat-form');
 const chatInput = document.getElementById('chat-input');
@@ -30,6 +29,10 @@ const chatInput = document.getElementById('chat-input');
 const themeToggle = document.getElementById('theme-toggle');
 const wizard = document.getElementById('wizard');
 const wizardCloseButton = document.getElementById('wizard-close');
+const wizardTitle = document.getElementById('wizard-title');
+const wizardSubtitle = document.getElementById('wizard-subtitle');
+const wizardInstructions = document.getElementById('wizard-instructions');
+const wizardDontShow = document.getElementById('wizard-dont-show');
 
 let currentSelectedText = '';
 let chat;
@@ -53,13 +56,26 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Lógica del Wizard
-    if (!localStorage.getItem('hasSeenWizard')) {
-        wizard.style.display = 'flex';
+    const shouldHideWizard = localStorage.getItem('hideWizard') === 'true';
+    if (!shouldHideWizard) {
+        openWizard();
     }
-    wizardCloseButton.addEventListener('click', () => {
-        wizard.style.display = 'none';
-
-        localStorage.setItem('hasSeenWizard', 'true');
+    if (wizardCloseButton) {
+        wizardCloseButton.addEventListener('click', () => {
+            closeWizard();
+        });
+    }
+    if (wizard) {
+        wizard.addEventListener('click', (event) => {
+            if (event.target === wizard) {
+                closeWizard();
+            }
+        });
+    }
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && wizard && wizard.style.display === 'flex') {
+            closeWizard();
+        }
     });
 
     // Carga de las instrucciones del sistema
@@ -140,6 +156,58 @@ function createElement(item) {
 
 function isMobileViewport() {
     return window.matchMedia('(max-width: 768px)').matches;
+}
+
+function openWizard() {
+    if (!wizard) return;
+    updateWizardContent();
+    if (wizardDontShow) {
+        wizardDontShow.checked = false;
+    }
+    wizard.style.display = 'flex';
+    wizard.setAttribute('aria-hidden', 'false');
+    if (wizardCloseButton) {
+        wizardCloseButton.focus();
+    }
+}
+
+function closeWizard() {
+    if (!wizard) return;
+    wizard.style.display = 'none';
+    wizard.setAttribute('aria-hidden', 'true');
+    if (wizardDontShow && wizardDontShow.checked) {
+        localStorage.setItem('hideWizard', 'true');
+    }
+}
+
+function updateWizardContent() {
+    if (!wizardTitle || !wizardSubtitle || !wizardInstructions) return;
+    const mobile = isMobileViewport();
+    const title = mobile ? 'Conversar desde tu dispositivo móvil' : 'Conversar desde tu ordenador';
+    const subtitle = mobile
+        ? 'Sigue estos pasos rápidos para seleccionar un fragmento y abrir el chat.'
+        : 'Descubre cómo iniciar una conversación contextual en tres pasos.';
+    const steps = mobile
+        ? [
+            'Pulsa el botón «Conversar» en la esquina superior izquierda para activar el modo de selección.',
+            'Selecciona un fragmento de al menos unas pocas palabras del documento.',
+            'Pulsa de nuevo «Conversar» para confirmar y abrir el chat contextual.',
+            'Escribe tus preguntas en la parte inferior del cajón y envíalas.'
+        ]
+        : [
+            'Selecciona un fragmento relevante del documento (unas pocas palabras o más).',
+            'Cuando aparezca el botón flotante «Conversar», haz clic en él para abrir el chat.',
+            'Formula tus preguntas en el campo de texto del cajón y envíalas.'
+        ];
+
+    wizardTitle.textContent = title;
+    wizardSubtitle.textContent = subtitle;
+    wizardInstructions.innerHTML = '';
+    steps.forEach((step) => {
+        const li = document.createElement('li');
+        li.textContent = step;
+        wizardInstructions.appendChild(li);
+    });
 }
 
 function showMobileSelectionHint(message, persistent = false) {
@@ -253,6 +321,9 @@ window.addEventListener('resize', () => {
     if (!isMobileViewport() && isMobileSelectionModeActive) {
         exitMobileSelectionMode({ clearSelection: false });
     }
+    if (wizard && wizard.style.display === 'flex') {
+        updateWizardContent();
+    }
 });
 
 // Refactorizado para evitar duplicar código
@@ -266,7 +337,6 @@ function openChatDrawer() {
         alert("La funcionalidad de IA no está disponible. Por favor, configura una clave de API en el archivo main.js.");
         return;
     }
-    selectedTextContainer.textContent = `"${currentSelectedText}"`;
     chatHistoryContainer.innerHTML = '';
     drawer.setAttribute('aria-hidden', 'false');
     drawer.removeAttribute('inert');
@@ -352,7 +422,7 @@ function addMessageToHistory(text, role) {
 function startChatSession() {
     const instructionTemplate = systemPrompt || `Eres un asistente experto en Arqueidentidad: Omicron. El usuario ha seleccionado el siguiente fragmento: "{{fragment}}". Inicia la conversación preguntando qué desea explorar.`;
     const systemInstruction = instructionTemplate.replace('{{fragment}}', currentSelectedText);
-    const firstMessage = `Has seleccionado el fragmento: "${currentSelectedText}". ¿Qué te gustaría explorar o preguntar sobre esta idea?`;
+    const firstMessage = `Trabajaremos con este fragmento: "${currentSelectedText}". ¿Qué te gustaría explorar o preguntar sobre esta idea?`;
 
     chat = model.startChat({
         history: [

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ if (API_KEY && API_KEY !== "AQUI_VA_TU_NUEVA_API_KEY") {
 const contentContainer = document.getElementById('content-container');
 const highlighterButton = document.getElementById('highlighter-button');
 const mobileChatTrigger = document.getElementById('mobile-chat-trigger');
+const mobileSelectionHint = document.getElementById('mobile-selection-hint');
 // Cajón de Chat
 const drawer = document.getElementById('chat-drawer');
 const drawerCloseButton = document.getElementById('drawer-close');
@@ -33,6 +34,12 @@ const wizardCloseButton = document.getElementById('wizard-close');
 let currentSelectedText = '';
 let chat;
 let systemPrompt = '';
+
+const MOBILE_MIN_SELECTION_LENGTH = 6;
+const MOBILE_SELECTION_PROMPT = 'Selecciona el fragmento que quieres conversar y toca Conversar para confirmar.';
+const MOBILE_SELECTION_READY = 'Toca Conversar para confirmar la selección.';
+let isMobileSelectionModeActive = false;
+let mobileHintTimeout = null;
 
 // --- LÓGICA PRINCIPAL DE LA APLICACIÓN ---
 document.addEventListener('DOMContentLoaded', () => {
@@ -131,33 +138,130 @@ function createElement(item) {
     return el;
 }
 
+function isMobileViewport() {
+    return window.matchMedia('(max-width: 768px)').matches;
+}
+
+function showMobileSelectionHint(message, persistent = false) {
+    if (!mobileSelectionHint) return;
+    mobileSelectionHint.textContent = message;
+    mobileSelectionHint.classList.add('visible');
+    if (mobileHintTimeout) {
+        clearTimeout(mobileHintTimeout);
+        mobileHintTimeout = null;
+    }
+    if (!persistent) {
+        mobileHintTimeout = setTimeout(() => {
+            mobileSelectionHint.classList.remove('visible');
+            mobileHintTimeout = null;
+        }, 3500);
+    }
+}
+
+function hideMobileSelectionHint() {
+    if (!mobileSelectionHint) return;
+    mobileSelectionHint.classList.remove('visible');
+    if (mobileHintTimeout) {
+        clearTimeout(mobileHintTimeout);
+        mobileHintTimeout = null;
+    }
+}
+
+function enterMobileSelectionMode() {
+    if (!mobileChatTrigger) return;
+    isMobileSelectionModeActive = true;
+    currentSelectedText = '';
+    mobileChatTrigger.classList.add('selection-mode');
+    mobileChatTrigger.classList.remove('ready');
+    mobileChatTrigger.setAttribute('aria-expanded', 'true');
+    const selection = window.getSelection();
+    if (selection && typeof selection.removeAllRanges === 'function') {
+        selection.removeAllRanges();
+    }
+    showMobileSelectionHint(MOBILE_SELECTION_PROMPT, true);
+}
+
+function exitMobileSelectionMode({ clearSelection = true, keepText = false } = {}) {
+    if (!mobileChatTrigger) return;
+    isMobileSelectionModeActive = false;
+    mobileChatTrigger.classList.remove('selection-mode', 'ready');
+    mobileChatTrigger.setAttribute('aria-expanded', 'false');
+    hideMobileSelectionHint();
+    if (!keepText) {
+        currentSelectedText = '';
+    }
+    if (clearSelection) {
+        const selection = window.getSelection();
+        if (selection && typeof selection.removeAllRanges === 'function') {
+            selection.removeAllRanges();
+        }
+    }
+}
+
+function handleMobileSelectionUpdate(selectedText) {
+    if (!mobileChatTrigger || !isMobileSelectionModeActive) return;
+    if (selectedText.length >= MOBILE_MIN_SELECTION_LENGTH) {
+        currentSelectedText = selectedText;
+        mobileChatTrigger.classList.add('ready');
+        showMobileSelectionHint(MOBILE_SELECTION_READY, true);
+    } else {
+        mobileChatTrigger.classList.remove('ready');
+        if (selectedText.length === 0) {
+            showMobileSelectionHint(MOBILE_SELECTION_PROMPT, true);
+        }
+    }
+}
+
 // MODIFICADO: Se añade 'touchend' para mejor respuesta en móviles
 ['mouseup', 'touchend'].forEach(evt => {
     document.addEventListener(evt, (event) => {
-        if (drawer.contains(event.target) || wizard.contains(event.target)) return;
-        
-        const selection = window.getSelection();
-        const selectedText = selection.toString().trim();
+        if ((drawer && drawer.contains(event.target)) || (wizard && wizard.contains(event.target))) return;
 
-        if (selectedText.length > 5) {
-            currentSelectedText = selectedText;
-            // Lógica para el botón de escritorio
-            const range = selection.getRangeAt(0);
-            const rect = range.getBoundingClientRect();
-            highlighterButton.style.display = 'block';
-            highlighterButton.style.left = `${rect.left + window.scrollX + (rect.width / 2) - (highlighterButton.offsetWidth / 2)}px`;
-            highlighterButton.style.top = `${rect.top + window.scrollY - highlighterButton.offsetHeight - 5}px`;
-            // Lógica para el botón móvil
-            mobileChatTrigger.classList.add('active');
+        const selection = window.getSelection();
+        const selectedText = selection ? selection.toString().trim() : '';
+
+        if (isMobileViewport()) {
+            if (!isMobileSelectionModeActive) return;
+            handleMobileSelectionUpdate(selectedText);
+            return;
+        }
+
+        if (selectedText.length >= MOBILE_MIN_SELECTION_LENGTH) {
+            if (selection && selection.rangeCount > 0) {
+                currentSelectedText = selectedText;
+                const range = selection.getRangeAt(0);
+                const rect = range.getBoundingClientRect();
+                highlighterButton.style.display = 'block';
+                highlighterButton.style.left = `${rect.left + window.scrollX + (rect.width / 2) - (highlighterButton.offsetWidth / 2)}px`;
+                highlighterButton.style.top = `${rect.top + window.scrollY - highlighterButton.offsetHeight - 5}px`;
+            }
         } else {
             highlighterButton.style.display = 'none';
-            mobileChatTrigger.classList.remove('active');
+            currentSelectedText = '';
         }
     });
 });
 
+document.addEventListener('selectionchange', () => {
+    if (!isMobileViewport() || !isMobileSelectionModeActive) return;
+    const selection = window.getSelection();
+    const selectedText = selection ? selection.toString().trim() : '';
+    handleMobileSelectionUpdate(selectedText);
+});
+
+window.addEventListener('resize', () => {
+    if (!isMobileViewport() && isMobileSelectionModeActive) {
+        exitMobileSelectionMode({ clearSelection: false });
+    }
+});
+
 // Refactorizado para evitar duplicar código
 function openChatDrawer() {
+    if (!currentSelectedText) {
+        alert('Selecciona un fragmento de texto antes de conversar.');
+        return;
+    }
+    exitMobileSelectionMode({ clearSelection: true, keepText: true });
     if (!genAI) {
         alert("La funcionalidad de IA no está disponible. Por favor, configura una clave de API en el archivo main.js.");
         return;
@@ -167,15 +271,23 @@ function openChatDrawer() {
     drawer.setAttribute('aria-hidden', 'false');
     drawer.removeAttribute('inert');
     highlighterButton.style.display = 'none';
-    mobileChatTrigger.classList.remove('active'); // Desactivar al abrir
     startChatSession();
-    drawerCloseButton.focus();
+    if (drawerCloseButton) {
+        drawerCloseButton.focus();
+    }
 }
 
 highlighterButton.addEventListener('click', openChatDrawer);
 mobileChatTrigger.addEventListener('click', () => {
-    if (mobileChatTrigger.classList.contains('active')) {
+    if (!isMobileViewport()) return;
+    if (!isMobileSelectionModeActive) {
+        enterMobileSelectionMode();
+        return;
+    }
+    if (currentSelectedText && currentSelectedText.length >= MOBILE_MIN_SELECTION_LENGTH) {
         openChatDrawer();
+    } else {
+        showMobileSelectionHint('Selecciona un fragmento más extenso antes de confirmar.', true);
     }
 });
 
@@ -183,6 +295,8 @@ function closeDrawer() {
     drawer.setAttribute('aria-hidden', 'true');
     drawer.setAttribute('inert', '');
     chat = null;
+    highlighterButton.style.display = 'none';
+    exitMobileSelectionMode({ clearSelection: true });
 }
 drawerCloseButton.addEventListener('click', closeDrawer);
 drawer.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- move the Conversar trigger to the top-left on mobile and add a helper hint panel
- add a dedicated mobile selection mode that users activate before picking text and confirm afterward
- update chat drawer handling to work with the explicit mobile selection state

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4339191d48325a3ac513a5bff5157