### PR TITLE
Center main content area on wide screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,18 @@
             transition: background-color 0.2s, color 0.2s;
         }
 
+        main#content-container {
+            width: 100%;
+            max-width: 960px;
+            margin: 0 auto;
+        }
+
+        @media (min-width: 1440px) {
+            main#content-container {
+                max-width: 1100px;
+            }
+        }
+
         h1, h2, h3, h4, p, blockquote, ul, li {
             margin-block-start: 1em;
             margin-block-end: 1em;

--- a/index.html
+++ b/index.html
@@ -37,13 +37,13 @@
 
         main#content-container {
             width: 100%;
-            max-width: 960px;
+            max-width: 720px;
             margin: 0 auto;
         }
 
         @media (min-width: 1440px) {
             main#content-container {
-                max-width: 1100px;
+                max-width: 720px;
             }
         }
 
@@ -53,7 +53,7 @@
         }
 
         p, li, blockquote {
-            font-size: 1.1em;
+            font-size: 1.3em;
             line-height: 1.6;
         }
 


### PR DESCRIPTION
## Summary
- limit the main content container width and center it on large viewports to prevent text from stretching edge-to-edge

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f7becefb6083259bd59695a8980d7f